### PR TITLE
(Attempt to) simplify libe2fs-sys build

### DIFF
--- a/libe2fs-sys/build-e2fs.sh
+++ b/libe2fs-sys/build-e2fs.sh
@@ -7,18 +7,11 @@ cd e2fsprogs
 # clean up previous state. this is mostly for dev.
 rm -rf ./build/
 
+# git clean -fd
 # git reset --hard HEAD
+
 # set up build dir
 mkdir -pv build
-
-# subs
-# yes, two passes are necessary. the first pass generates the subs files, and
-# the second ./configure actually configures for build.
-env CC="musl-gcc" ./configure
-make subs
-make lib/ext2fs/ext2_types.h
-
-# build!
 cd build
 
 # fix includes for flat includes
@@ -33,6 +26,10 @@ sed -i -e 's|#include "com_err.h"|#include "../et/com_err.h"|g' ../lib/ext2fs/ex
 # configure! autotools! pain! :D
 env CC="musl-gcc" CFLAGS="-DEXT2_FLAT_INCLUDES=1" ../configure
 
+# generate subs and ext2 types header
+make subs -j
+make lib/ext2fs/ext2_types.h
+
 # patch makefile to only build libext2fs
 perl -i -pe 's/LIB_SUBDIRS=.*\n.*$/LIB_SUBDIRS=lib\/et \$\(EXT2FS_LIB_SUBDIR\) #/igs' Makefile
 
@@ -41,5 +38,4 @@ perl -i -pe 's/LIB_SUBDIRS=.*\n.*$/LIB_SUBDIRS=lib\/et \$\(EXT2FS_LIB_SUBDIR\) #
 cp ../util/subst* ./util/
 
 # do the meme!
-make subs
-env CC="musl-gcc" CFLAGS="-DEXT2_FLAT_INCLUDES=1" LDFLAGS="-Wl,static" make libs
+env CC="musl-gcc" CFLAGS="-DEXT2_FLAT_INCLUDES=1" LDFLAGS="-Wl,static" make -j libs

--- a/libe2fs-sys/build.rs
+++ b/libe2fs-sys/build.rs
@@ -68,9 +68,12 @@ fn main() {
         // The input header we would like to generate
         // bindings for.
         .header("wrapper.h")
-        // We need some types from our normal directory, and some in our build directory.
+        // We need some head from our source directory, and
+        // some generated within our build directory.
         .clang_arg(format!("-I{}/_build/e2fsprogs/lib/ext2fs", &out_dir))
         .clang_arg(format!("-I{}/_build/e2fsprogs/build/lib/ext2fs", &out_dir))
+        // for <et/com_err.h>
+        .clang_arg(format!("-I{}/_build/e2fsprogs/lib", &out_dir))
         .derive_debug(true)
         .derive_copy(true)
         // Tell cargo to invalidate the built crate whenever any of the

--- a/libe2fs-sys/wrapper.h
+++ b/libe2fs-sys/wrapper.h
@@ -1,5 +1,5 @@
 #define EXT2_FLAT_INCLUDES 1
-#include "e2fsprogs/lib/ext2fs/ext2fs.h"
+#include "ext2fs.h"
 
 struct ext2fs_struct_generic_bitmap_32
 {


### PR DESCRIPTION
By only running `configure` once, build times are much faster. Additionally, `make -j` speeds up build times by about 30 seconds on average, which helps somewhat. (Should this be replaced with `-j $(nproc)` or similar?)

Additionally, instead of copying headers into the project directory, the include path of `bindgen` is adjusted to include both the `$OUT_DIR` e2fsprogs source, and `$OUT_DIR` e2fsprogs build directory.

---
Not quite certain this is the cleanest approach - very much would welcome thoughts/comments!