### PR TITLE
Use ffi c_char

### DIFF
--- a/flail/src/ext/facade.rs
+++ b/flail/src/ext/facade.rs
@@ -545,7 +545,7 @@ impl<'a> FloppyDirEntry<'a, ExtFacadeFloppyDisk> for ExtFacadeDirEntry {
         // SAFETY: We just got this struct (and therefore pointer) from e2fs.
         unsafe {
             OsString::from_vec(
-                CString::from_raw(self.entry.name.as_ptr() as *mut i8)
+                CString::from_raw(self.entry.name.as_ptr() as *mut ::std::ffi::c_char)
                     .as_bytes()
                     .to_vec(),
             )


### PR DESCRIPTION
On some architectures (specifically anything ARM and PowerPC-based), C's `char` can be unsigned. Using ffi's type allows the source to be more agnostic, and lets Rust determine what fits the target architecture best (`i8` vs `u8`).